### PR TITLE
Improve error messages around dynamic resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,9 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/zclconf/go-cty v1.12.1 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect

--- a/go.sum
+++ b/go.sum
@@ -226,6 +226,13 @@ github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37w
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -14,6 +14,7 @@ import (
 	provider_schema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	tfresource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/hashicorp/terraform-provider-tfcoremock/internal/client"
 	"github.com/hashicorp/terraform-provider-tfcoremock/internal/resource"
 	"github.com/hashicorp/terraform-provider-tfcoremock/internal/schema/complex"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -13,8 +14,6 @@ import (
 	provider_schema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	tfresource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-
 	"github.com/hashicorp/terraform-provider-tfcoremock/internal/client"
 	"github.com/hashicorp/terraform-provider-tfcoremock/internal/resource"
 	"github.com/hashicorp/terraform-provider-tfcoremock/internal/schema/complex"
@@ -139,8 +138,19 @@ func (m *tfcoremockProvider) Resources(ctx context.Context) []func() tfresource.
 
 	schemas, err := m.reader.Read()
 	if err != nil {
-		tflog.Error(ctx, err.Error())
-		return resources
+		// This isn't ideal, as the plugin will tell the user this is a problem
+		// with the provider. It's not though, this means the provided dynamic
+		// resources file either wasn't valid JSON or didn't match our schema.
+		//
+		// We don't have a way to raise an error through the plugin at this
+		// point in time though, so the only thing we can really do is panic.
+		//
+		// We add a lot of context to this panic to try and make the caller
+		// realise exactly what the problem is.
+		panic(fmt.Sprintf("The tfcoremock provider either failed to parse or failed to validate your dynamic resources file. "+
+			"Terraform will say this is a problem in the provider, but in this case it is a problem in your dynamic resources file. "+
+			"We have the following error from the parser, hopefully it provides additional context about the problem but these errors are not always helpful."+
+			"\n\n%s\n", err.Error()))
 	}
 
 	for name, schema := range schemas {
@@ -178,8 +188,19 @@ func (m *tfcoremockProvider) DataSources(ctx context.Context) []func() datasourc
 
 	schemas, err := m.reader.Read()
 	if err != nil {
-		tflog.Error(ctx, err.Error())
-		return datasources
+		// This isn't ideal, as the plugin will tell the user this is a problem
+		// with the provider. It's not though, this means the provided dynamic
+		// resources file either wasn't valid JSON or didn't match our schema.
+		//
+		// We don't have a way to raise an error through the plugin at this
+		// point in time though, so the only thing we can really do is panic.
+		//
+		// We add a lot of context to this panic to try and make the caller
+		// realise exactly what the problem is.
+		panic(fmt.Sprintf("The tfcoremock provider either failed to parse or failed to validate your dynamic resources file. "+
+			"Terraform will say this is a problem in the provider, but in this case it is a problem in your dynamic resources file. "+
+			"We have the following error from the parser, hopefully it provides additional context about the problem but these errors are not always helpful."+
+			"\n\n%s\n", err.Error()))
 	}
 
 	for name, schema := range schemas {

--- a/internal/resource/data_source.go
+++ b/internal/resource/data_source.go
@@ -6,6 +6,7 @@ package resource
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"

--- a/internal/schema/attribute.go
+++ b/internal/schema/attribute.go
@@ -5,10 +5,12 @@ package schema
 
 import (
 	"fmt"
+
 	datasource_schema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	resource_schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-provider-tfcoremock/internal/data"
 	"github.com/pkg/errors"
+
+	"github.com/hashicorp/terraform-provider-tfcoremock/internal/data"
 )
 
 // Attribute defines an internal representation of a Terraform attribute in a

--- a/internal/schema/attribute.go
+++ b/internal/schema/attribute.go
@@ -99,6 +99,8 @@ func ToTerraformAttribute[A any](a Attribute, types *AttributeTypes[A]) (*A, err
 		}
 
 		return types.asNestedObject(a)
+	case "":
+		return nil, fmt.Errorf("missing attribute type")
 	default:
 		return nil, fmt.Errorf("unrecognized attribute type '%s'", a.Type)
 	}

--- a/internal/schema/dynamic/dynamic.go
+++ b/internal/schema/dynamic/dynamic.go
@@ -13,10 +13,7 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/hashicorp/terraform-provider-tfcoremock/internal/schema"
-)
-
-const (
-	dynamicResourcesSchemaEnvVarName = "TFCOREMOCK_DYNAMIC_RESOURCES_SCHEMA"
+	jsonschema "github.com/hashicorp/terraform-provider-tfcoremock/schema"
 )
 
 type Reader interface {
@@ -32,15 +29,13 @@ type StringReader struct {
 }
 
 func (r FileReader) Read() (map[string]schema.Schema, error) {
-	dynamicResourcesSchema := "https://raw.githubusercontent.com/hashicorp/terraform-provider-tfcoremock/main/schema/dynamic_resources.json"
-	if dynamicResourcesSchemaEnvVar := os.Getenv(dynamicResourcesSchemaEnvVarName); dynamicResourcesSchemaEnvVar != "" {
-		dynamicResourcesSchema = dynamicResourcesSchemaEnvVar
-	}
-
-	schemaLoader := gojsonschema.NewReferenceLoader(dynamicResourcesSchema)
+	schemaLoader := gojsonschema.NewStringLoader(jsonschema.DynamicResourcesJsonSchema)
 
 	data, err := os.ReadFile(r.File)
 	if err != nil {
+		// TODO(liamcervante): It's okay if there is no dynamic_resources.json
+		//   file, but if the user has set the environment variable changing the
+		//   location maybe we should complain about it?
 		if os.IsNotExist(err) {
 			return nil, nil
 		}

--- a/internal/schema/dynamic/dynamic.go
+++ b/internal/schema/dynamic/dynamic.go
@@ -5,9 +5,18 @@ package dynamic
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/hashicorp/terraform-provider-tfcoremock/internal/schema"
+)
+
+const (
+	dynamicResourcesSchemaEnvVarName = "TFCOREMOCK_DYNAMIC_RESOURCES_SCHEMA"
 )
 
 type Reader interface {
@@ -23,22 +32,44 @@ type StringReader struct {
 }
 
 func (r FileReader) Read() (map[string]schema.Schema, error) {
+	dynamicResourcesSchema := "https://raw.githubusercontent.com/hashicorp/terraform-provider-tfcoremock/main/schema/dynamic_resources.json"
+	if dynamicResourcesSchemaEnvVar := os.Getenv(dynamicResourcesSchemaEnvVarName); dynamicResourcesSchemaEnvVar != "" {
+		dynamicResourcesSchema = dynamicResourcesSchemaEnvVar
+	}
+
+	schemaLoader := gojsonschema.NewReferenceLoader(dynamicResourcesSchema)
+
 	data, err := os.ReadFile(r.File)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
+		return nil, errors.Wrap(err, "failed to read dynamic resources file")
+	}
+
+	documentLoader := gojsonschema.NewStringLoader(string(data))
+	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	if err != nil {
 		return nil, err
 	}
 
-	var dynamicResources map[string]schema.Schema
-	if len(data) > 0 {
-		if err := json.Unmarshal(data, &dynamicResources); err != nil {
-			return nil, err
+	if result.Valid() {
+		var dynamicResources map[string]schema.Schema
+		if len(data) > 0 {
+			if err := json.Unmarshal(data, &dynamicResources); err != nil {
+				return nil, errors.Wrap(err, "failed to unmarshal dynamic resources json")
+			}
 		}
+
+		return dynamicResources, nil
 	}
 
-	return dynamicResources, nil
+	var errs []string
+	for _, err := range result.Errors() {
+		errs = append(errs, err.String())
+	}
+
+	return nil, fmt.Errorf("failed json schema check: %s", strings.Join(errs, ", "))
 }
 
 func (r StringReader) Read() (map[string]schema.Schema, error) {

--- a/schema/dynamic_resources.json
+++ b/schema/dynamic_resources.json
@@ -60,7 +60,7 @@
       "type": "object",
       "properties": {
         "boolean": { "type":  "boolean" },
-        "number": { "type": "string" },
+        "number": { "type": "number" },
         "string": { "type": "string" },
         "list": {
           "type": "array",

--- a/schema/dynamic_resources.json
+++ b/schema/dynamic_resources.json
@@ -60,7 +60,7 @@
       "type": "object",
       "properties": {
         "boolean": { "type":  "boolean" },
-        "number": { "type": "number" },
+        "number": { "type": "string" },
         "string": { "type": "string" },
         "list": {
           "type": "array",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,0 +1,6 @@
+package schema
+
+import _ "embed"
+
+//go:embed dynamic_resources.json
+var DynamicResourcesJsonSchema string


### PR DESCRIPTION
Fixes #34 

This PR makes the provider validate the provided JSON file against the schema, and panics in case it can't read the file/parse the json/validate. Previously, it would have just logged an error message that wasn't visible unless the user had TF_LOG enabled.

The panic isn't ideal as the framework reports this as an error in the provider, but the panic message contains context that the panic was caused by the dynamic resources file. There is no way to properly raise an error to the framework at the point in time the dynamic resource is being read.