### PR TITLE
Computed attributes don't have to return a value

### DIFF
--- a/internal/data/value.go
+++ b/internal/data/value.go
@@ -230,7 +230,7 @@ func objectFromTerraform5Value(v tftypes.Value) (Value, error) {
 
 	values := make(map[string]Value)
 	for name, child := range children {
-		if child.IsNull() {
+		if child.IsNull() || !child.IsKnown() {
 			// Terraform handles unset objects differently to us. We just don't
 			// add unset attributes to our objects while terraform adds them
 			// but sets them to null. If this child value is null in the
@@ -239,6 +239,9 @@ func objectFromTerraform5Value(v tftypes.Value) (Value, error) {
 			// Note, the reverse implementation in objectToTerrafrom5Value. We
 			// check the type information and set any missing attributes as null
 			// when converting into the terraform representation.
+			//
+			// For now, we also treat unknown values the same as null by just
+			// skipping them. Any computed values will be filled in later.
 			continue
 		}
 

--- a/internal/provider/resource_test.go
+++ b/internal/provider/resource_test.go
@@ -155,12 +155,8 @@ func TestAccDynamicResourceWithComputed(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("tfcoremock_dynamic_resource.test", "object_with_value.boolean", "true"),
 					resource.TestCheckResourceAttr("tfcoremock_dynamic_resource.test", "object_with_value.string", "hello"),
-					resource.TestCheckResourceAttrSet("tfcoremock_dynamic_resource.test", "computed_object.id"),
 					resource.TestCheckResourceAttr("tfcoremock_dynamic_resource.test", "computed_list.#", "0"),
-					resource.TestCheckResourceAttr("tfcoremock_dynamic_resource.test", "set.#", "3"),
-					resource.TestCheckResourceAttrSet("tfcoremock_dynamic_resource.test", "set.0.id"),
-					resource.TestCheckResourceAttrSet("tfcoremock_dynamic_resource.test", "set.1.id"),
-					resource.TestCheckResourceAttrSet("tfcoremock_dynamic_resource.test", "set.2.id")),
+					resource.TestCheckResourceAttr("tfcoremock_dynamic_resource.test", "set.#", "3")),
 			},
 			{
 				Config: LoadFile(t, "testdata/dynamic/delete/main.tf"),
@@ -180,9 +176,6 @@ func TestAccDynamicResourceWithComputedBlocks(t *testing.T) {
 					resource.TestCheckResourceAttr("tfcoremock_dynamic_resource.test", "other.#", "2"),
 					resource.TestCheckResourceAttr("tfcoremock_dynamic_resource.test", "other.0.id", "my-id"),
 					resource.TestCheckResourceAttr("tfcoremock_dynamic_resource.test", "other.0.nested.#", "2"),
-					resource.TestCheckResourceAttrSet("tfcoremock_dynamic_resource.test", "other.0.nested.0.id"),
-					resource.TestCheckResourceAttrSet("tfcoremock_dynamic_resource.test", "other.0.nested.1.id"),
-					resource.TestCheckResourceAttrSet("tfcoremock_dynamic_resource.test", "other.1.id"),
 					resource.TestCheckResourceAttr("tfcoremock_dynamic_resource.test", "object.#", "0")),
 			},
 			{

--- a/schema/dynamic_resources.json
+++ b/schema/dynamic_resources.json
@@ -59,23 +59,23 @@
     "value": {
       "type": "object",
       "properties": {
-        "boolean": { "type":  "boolean" },
-        "number": { "type": "string" },
-        "string": { "type": "string" },
+        "boolean": { "type":  ["boolean", "null"] },
+        "number": { "type": ["string", "null"] },
+        "string": { "type": ["string", "null"] },
         "list": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": { "$ref": "#/definitions/value" }
         },
         "map": {
-          "type": "object",
+          "type": ["object", "null"],
           "additionalProperties": { "$ref": "#/definitions/value" }
         },
         "object": {
-          "type": "object",
+          "type": ["object", "null"],
           "additionalProperties": { "$ref": "#/definitions/value" }
         },
         "set": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": { "$ref": "#/definitions/value" }
         }
       },


### PR DESCRIPTION
I learned recently that computed attributes don't have to return values.

This PR makes the provider only set values in computed resources if the value attribute is set in the JSON schema. It also tidies up the update logic, so that it can recompute and handle empty computed values.