### PR TITLE
Install Terraform before running go generate in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       - run: go generate ./...
       - name: git diff
         run: |


### PR DESCRIPTION
We need a running version of Terraform to run `go generate ./...` as it uses Terraform to generate the documentation.