### PR TITLE
chore: Update copyright headers to reflect that it's 2026

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package client

--- a/internal/client/local.go
+++ b/internal/client/local.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package client

--- a/internal/client/state.go
+++ b/internal/client/state.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package client

--- a/internal/computed/computed.go
+++ b/internal/computed/computed.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package computed

--- a/internal/data/resource.go
+++ b/internal/data/resource.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package data

--- a/internal/data/resource_test.go
+++ b/internal/data/resource_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package data

--- a/internal/data/value.go
+++ b/internal/data/value.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package data

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/resource_test.go
+++ b/internal/provider/resource_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/resource/data_source.go
+++ b/internal/resource/data_source.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package resource

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package resource

--- a/internal/schema/attribute.go
+++ b/internal/schema/attribute.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package schema

--- a/internal/schema/block.go
+++ b/internal/schema/block.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package schema

--- a/internal/schema/complex/complex.go
+++ b/internal/schema/complex/complex.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package complex

--- a/internal/schema/datasource.go
+++ b/internal/schema/datasource.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package schema

--- a/internal/schema/dynamic/dynamic.go
+++ b/internal/schema/dynamic/dynamic.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package dynamic

--- a/internal/schema/resource.go
+++ b/internal/schema/resource.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package schema

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package schema

--- a/internal/schema/simple/simple.go
+++ b/internal/schema/simple/simple.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package simple

--- a/internal/schema/types.go
+++ b/internal/schema/types.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package schema

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package main

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package schema

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2022, 2025
+// Copyright IBM Corp. 2022, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build tools


### PR DESCRIPTION
## Description

Happy 2026 (even though it's March)!

Dependabot PRs had failing checks, which this PR addresses.

Note: This was done via the copywrite tool, not manually

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

**Nope.**